### PR TITLE
Bump version to allow 2.8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   ],
   "require": {
     "php": ">=5.5.0",
-    "symfony/http-kernel": "~2.6.7|~2.7.0",
+    "symfony/http-kernel": "~2.6.7|~2.7.0|~2.8.0|~3.0.0",
     "neomerx/json-api": "~0.6.0"
   },
   "require-dev": {


### PR DESCRIPTION
I've tested this with 2.8.0 and it works.  3.0 shouldn't be a problem either, but I haven't tested with it yet.
